### PR TITLE
First complete k10 build

### DIFF
--- a/sys/src/nix/ip/ip.h
+++ b/sys/src/nix/ip/ip.h
@@ -546,7 +546,7 @@ extern void	arpenter(Fs*, int version, uchar *ip, uchar *mac, int len, int noref
 
 extern int	myetheraddr(uchar*, char*);
 extern vlong	parseip(uchar*, char*);
-extern vlong	parseipmask(uchar*, char*);
+extern vlong	parseipmask(uchar*, char*, int);
 extern char*	v4parseip(uchar*, char*);
 extern void	maskip(uchar *from, uchar *mask, uchar *to);
 extern int	parsemac(uchar *to, char *from, int len);

--- a/sys/src/nix/ip/ipifc.c
+++ b/sys/src/nix/ip/ipifc.c
@@ -391,13 +391,13 @@ ipifcadd(Ipifc *ifc, char **argv, int argc, int tentative, Iplifc *lifcp)
 		/* fall through */
 	case 4:
 		parseip(ip, argv[1]);
-		parseipmask(mask, argv[2]);
+		parseipmask(mask, argv[2], 0);
 		parseip(rem, argv[3]);
 		maskip(rem, mask, net);
 		break;
 	case 3:
 		parseip(ip, argv[1]);
-		parseipmask(mask, argv[2]);
+		parseipmask(mask, argv[2], 0);
 		maskip(ip, mask, rem);
 		maskip(rem, mask, net);
 		break;
@@ -591,7 +591,7 @@ ipifcrem(Ipifc *ifc, char **argv, int argc)
 		return Ebadarg;
 
 	parseip(ip, argv[1]);
-	parseipmask(mask, argv[2]);
+	parseipmask(mask, argv[2], 0);
 	if(argc < 4)
 		maskip(ip, mask, rem);
 	else

--- a/sys/src/nix/ip/iproute.c
+++ b/sys/src/nix/ip/iproute.c
@@ -816,7 +816,7 @@ routewrite(Fs *f, Chan *c, char *p, int n)
 		if(cb->nf < 3)
 			error(Ebadarg);
 		parseip(addr, cb->f[1]);
-		parseipmask(mask, cb->f[2]);
+		parseipmask(mask, cb->f[2], 0);
 		if(memcmp(addr, v4prefix, IPv4off) == 0)
 			v4delroute(f, addr+IPv4off, mask+IPv4off, 1);
 		else
@@ -825,7 +825,7 @@ routewrite(Fs *f, Chan *c, char *p, int n)
 		if(cb->nf < 4)
 			error(Ebadarg);
 		parseip(addr, cb->f[1]);
-		parseipmask(mask, cb->f[2]);
+		parseipmask(mask, cb->f[2], 0);
 		parseip(gate, cb->f[3]);
 		tag = "none";
 		if(c != nil){

--- a/sys/src/nix/k10/devacpi.c
+++ b/sys/src/nix/k10/devacpi.c
@@ -8,6 +8,8 @@
 #include "mp.h"
 #include "acpi.h"
 
+extern void qqsort(void *va, long n, long es, int (*cmp)(void*, void*));
+
 /*
  * ACPI 4.0 Support.
  * Still WIP.
@@ -808,7 +810,7 @@ acpislit(uchar *p, int len)
 	}
 	dumpslit(slit);
 	for(i = 0; i < slit->rowlen; i++)
-		qsort(slit->e[i], slit->rowlen, sizeof(slit->e[0][0]), cmpslitent);
+		qqsort(slit->e[i], slit->rowlen, sizeof(slit->e[0][0]), cmpslitent);
 	
 	dumpslit(slit);
 	return nil;	/* can be unmapped once parsed */

--- a/sys/src/nix/k10/k8cpu
+++ b/sys/src/nix/k10/k8cpu
@@ -121,6 +121,7 @@ dbgflg
 	mmu		'v'
 
 amd64 +dev
+	qqsort
 	l32p
 	l64v
 	l64idt

--- a/sys/src/nix/k10/k8cpufs
+++ b/sys/src/nix/k10/k8cpufs
@@ -117,6 +117,7 @@ dbgflg
 	memory 'm'
 
 amd64 +dev
+	qqsort
 	l32p
 	l64v
 	l64idt

--- a/sys/src/nix/k10/qqsort.c
+++ b/sys/src/nix/k10/qqsort.c
@@ -1,8 +1,11 @@
 /*
+ * PAL: a gross hack for a linker problem
+ */
+/*
  * qsort -- simple quicksort
  */
 
-#include <u.h>
+#include "u.h"
 
 typedef
 struct
@@ -111,7 +114,7 @@ qsorts(char *a, usize n, Sort *p)
 }
 
 void
-qsort(void *va, long n, long es, int (*cmp)(void*, void*))
+qqsort(void *va, long n, long es, int (*cmp)(void*, void*))
 {
 	Sort s;
 

--- a/sys/src/nix/nix
+++ b/sys/src/nix/nix
@@ -12,5 +12,3 @@ for(d in man/*){
 # Set up git.
 cd ..
 git/fs
-
-/sys/src/libc/9syscall/sys.h

--- a/sys/src/nix/nix
+++ b/sys/src/nix/nix
@@ -1,9 +1,9 @@
 #!/bin/rc
 objtype=amd64
 unmount /sys/include >[2]/dev/null
-unmount /sys/src/libc >[2]/dev/null
+unmount /sys/src/libc/9syscall >[2]/dev/null
 bind -b /usr/glenda/nix-os/sys/include /sys/include
-bind -c /usr/glenda/nix-os/sys/src/libc /sys/src/libc
+bind -c /usr/glenda/nix-os/sys/src/libc/9syscall /sys/src/libc/9syscall
 cd /usr/glenda/nix-os/sys
 for(d in man/*){
 	unmount /sys/$d >[2]/dev/null
@@ -12,4 +12,5 @@ for(d in man/*){
 # Set up git.
 cd ..
 git/fs
-exit ''
+
+/sys/src/libc/9syscall/sys.h


### PR DESCRIPTION
Add a temporary qqsort to get around qsort linkage grief with devacpi parseipmask has a 0 for v4; I don't know if this breaks IPv6.  It needs more attention.