### PR TITLE
Check for minimum (64M) memory, assert if not found.

### DIFF
--- a/sys/src/nix/k10/fns.h
+++ b/sys/src/nix/k10/fns.h
@@ -98,6 +98,7 @@ int	mmukmapsync(uvlong);
 uintmem	mmuphysaddr(uintptr);
 int	mmuwalk(PTE*, uintptr, int, PTE**, PTE (*)(usize));
 int	multiboot(u32int, u32int, int);
+void	multibootmemassert(u32int pmbi);
 void	ndnr(void);
 uchar	nvramread(int);
 void	nvramwrite(int, uchar);

--- a/sys/src/nix/k10/main.c
+++ b/sys/src/nix/k10/main.c
@@ -306,6 +306,7 @@ main(u32int ax, u32int bx)
 	mmuinit();
 
 	ioinit();
+	multibootmemassert(bx); /* This test is so far down because we want panic() to be setup */
 	kbdinit();
 	meminit();
 	confinit();

--- a/sys/src/nix/k10/map.c
+++ b/sys/src/nix/k10/map.c
@@ -7,8 +7,6 @@
 #define _KADDR(pa)	UINT2PTR(kseg0+((uintptr)(pa)))
 #define _PADDR(va)	PTR2UINT(((uintptr)(va)) - kseg0)
 
-#define TMFM		(64*MiB)
-
 void*
 KADDR(uintptr pa)
 {

--- a/sys/src/nix/k10/mem.h
+++ b/sys/src/nix/k10/mem.h
@@ -40,6 +40,8 @@
 #define KSTACK		(16*1024)		/* Size of Proc kernel stack */
 #define STACKALIGN(sp)	((sp) & ~(BY2SE-1))	/* bug: assure with alloc */
 
+#define TMFM		(64*MiB)		/* kernel memory */
+
 /*
  * 2M pages
  * these defines must go.

--- a/sys/src/nix/k10/mmu.c
+++ b/sys/src/nix/k10/mmu.c
@@ -14,9 +14,6 @@
  *	mmuptcopy (PteSHARED trick?);
  *	calculate and map up to TMFM (conf crap);
  */
-
-#define TMFM		(64*MiB)		/* kernel memory */
-
 #define PPN(x)		((x)&~(PGSZ-1))
 
 void

--- a/sys/src/nix/k10/multiboot.c
+++ b/sys/src/nix/k10/multiboot.c
@@ -55,6 +55,16 @@ struct MMap {
 	u32int	type;
 };
 
+void
+multibootmemassert(u32int pmbi)
+{
+	Mbi *mbi;
+
+	mbi = KADDR(pmbi);
+	if ((mbi->memupper << 10) + (1<<20) < TMFM)
+		panic("multiboot: Must have at least %0dMB RAM: Only %0d provided\n", TMFM>>20, ((mbi->memupper << 10) + (1<<20))>>20);
+}
+
 int
 multiboot(u32int magic, u32int pmbi, int vflag)
 {


### PR DESCRIPTION
This is because the kernel assumes there is 64M of ram available (sys/src/nix/k10/mem.h:/TMFM). 64M just also happens to be the default for vmx.