### PR TITLE
Add local as a boot method.

### DIFF
--- a/sys/src/nix/k10/k8cpu
+++ b/sys/src/nix/k10/k8cpu
@@ -27,6 +27,7 @@ misc +dev
 	mp		apic ioapic msi pci sipi
 
 boot cpu
+	local
 
 rootdir
 	bootk8cpu.out boot


### PR DESCRIPTION
This makes it possible to boot off local disk.
But it's a long way to a working disk image given the divergence in boot process in 9front.
